### PR TITLE
Civil Surface added

### DIFF
--- a/Src/CivilConnection/2020/Autodesk2020/Autodesk2020.csproj
+++ b/Src/CivilConnection/2020/Autodesk2020/Autodesk2020.csproj
@@ -146,6 +146,7 @@
     <Compile Include="CableTray.cs" />
     <Compile Include="CivilApplication.cs" />
     <Compile Include="CivilDocument.cs" />
+    <Compile Include="CivilSurface.cs" />
     <Compile Include="Conduit.cs" />
     <Compile Include="Connector.cs" />
     <Compile Include="Corridor.cs" />

--- a/Src/CivilConnection/2020/Autodesk2020/CivilDocument.cs
+++ b/Src/CivilConnection/2020/Autodesk2020/CivilDocument.cs
@@ -66,6 +66,10 @@ namespace CivilConnection
         /// The internal element.
         /// </value>
         internal object InternalElement { get { return this._document; } }
+        /// <summary>
+        /// Surfaces
+        /// </summary>
+        private AeccSurfaces _surfaces;
         #endregion
 
         #region CONSTRUCTORS
@@ -78,6 +82,7 @@ namespace CivilConnection
             this._document = _doc;
             _corridors = _doc.Corridors;
             _alignments = _doc.AlignmentsSiteless;
+            _surfaces = _doc.Surfaces;
         }
         #endregion
 
@@ -238,6 +243,37 @@ namespace CivilConnection
         public Alignment GetAlignmentByName(string name)
         {
             return this.GetAlignments().First(x => x.Name == name);
+        }
+
+        /// <summary>
+        /// Gets all surfaces
+        /// </summary>
+        /// <returns>
+        /// List of surfaces
+        /// </returns>
+        public IList<CivilSurface> GetSurfaces()
+        {
+            Utils.Log(string.Format("CivilDocument.GetSurfaces started...", ""));
+
+            IList<CivilSurface> output = new List<CivilSurface>();
+            foreach (AeccSurface s in this._surfaces)
+            {
+                output.Add(new CivilSurface(s));
+            }
+
+            Utils.Log(string.Format("CivilDocument.GetSurfaces completed.", ""));
+
+            return output;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public CivilSurface GetSurfaceByName(string name)
+        {
+            return this.GetSurfaces().First(x => x.Name == name);
         }
 
         #region AUTOCAD METHODS

--- a/Src/CivilConnection/2020/Autodesk2020/CivilDocument.cs
+++ b/Src/CivilConnection/2020/Autodesk2020/CivilDocument.cs
@@ -267,10 +267,12 @@ namespace CivilConnection
         }
 
         /// <summary>
-        /// 
+        /// Get surface by name.
         /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
+        /// <param name="name">The name of surface</param>
+        /// <returns>
+        /// Civil Surface
+        /// </returns>
         public CivilSurface GetSurfaceByName(string name)
         {
             return this.GetSurfaces().First(x => x.Name == name);

--- a/Src/CivilConnection/2020/Autodesk2020/CivilSurface.cs
+++ b/Src/CivilConnection/2020/Autodesk2020/CivilSurface.cs
@@ -1,0 +1,257 @@
+﻿using Autodesk.AECC.Interop.Land;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autodesk.DesignScript.Runtime;
+using Autodesk.DesignScript.Geometry;
+
+namespace CivilConnection
+{
+    /// <summary>
+    /// Civil 3D Surface object
+    /// </summary>
+    public class CivilSurface
+    {
+        #region PRIVATE PROPERTIES
+        private AeccSurface _surface;
+        private AeccSurfaceBoundaries _boundaries;
+        #endregion
+
+        #region PUBLIC PROPERTIES
+        /// <summary>
+        /// Gets the name of surface
+        /// </summary>
+        /// <value>
+        /// Name of surface
+        /// </value>
+        public string Name { get { return _surface.Name; } }
+        /// <summary>
+        /// Gets the surface type
+        /// </summary>
+        public AeccSurfaceType SurfaceType { get { return _surface.Type; } }
+        #endregion
+
+        #region INTERNAL CONSTRUCTOR
+        /// <summary>
+        /// Gets the internal element
+        /// </summary>
+        internal object Internal { get { return this._surface; } }
+        /// <summary>
+        /// Internal constructor
+        /// </summary>
+        /// <param name="surface">the internal AeccSurface</param>
+        internal CivilSurface(AeccSurface surface)
+        {
+            this._surface = surface;
+            this._boundaries = surface.Boundaries;
+        }
+        #endregion
+
+        #region PUBLIC METHODS
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="points"></param>
+        /// <returns></returns>
+        public List<object> GetElevationAtPoint(List<Point> points)
+        {
+            List<object> elevations = new List<object>();
+            foreach (Point point in points)
+            {
+                try
+                {
+                    double elevation = Math.Round(this._surface.FindElevationAtXY(point.X, point.Y), 3);
+                    elevations.Add(elevation);
+                }
+
+                catch
+                {
+                    elevations.Add("The surface elevation at selected point is not found");
+                }
+
+            }
+            return elevations;
+        }
+
+        /// <summary>
+        /// Gets all surface points along line
+        /// </summary>
+        /// <param name="lines"></param>
+        /// <returns></returns>
+        public List<List<object>> GetElevationsAlongLine(List<Line> lines)
+        {
+            List<List<object>> pointsOnLine = new List<List<object>>();
+            foreach (Line line in lines)
+            {
+                List<object> pointList = new List<object>();
+                Point startPoint = line.StartPoint;
+                Point endPoint = line.EndPoint;
+                double[] surfacePoints = this._surface.SampleElevations(startPoint.X, startPoint.Y, endPoint.X, endPoint.Y);
+                for (int i = 0; i < surfacePoints.Length; i += 3)
+                {
+                    double pX = surfacePoints[i];
+                    double pY = surfacePoints[i + 1];
+                    double pZ = surfacePoints[i + 2];
+                    Point point = Point.ByCoordinates(pX, pY, pZ);
+                    pointList.Add(point);
+                }
+                pointsOnLine.Add(pointList);
+            }
+            return pointsOnLine;
+        }
+
+        /// <summary>
+        /// Get all surface points
+        /// </summary>
+        /// <returns>
+        /// Point(X,Y,Z)
+        /// </returns>
+        public List<Point> GetSurfacePoints()
+        {
+            List<Point> pointList = new List<Point>();
+            double[] points = this._surface.Points;
+
+            for (int i = 0; i < points.Length; i += 3)
+            {
+                Point p = Point.ByCoordinates(points[i], points[i + 1], points[i + 2]);
+                pointList.Add(p);
+            }
+
+            return pointList;
+        }
+
+        /// <summary>
+        /// Gets all surface points between lower and upper limit point
+        /// </summary>
+        /// <param name="LowerLeftPoint"></param>
+        /// <param name="UpperRightPoint"></param>
+        /// <returns>
+        /// Point(X, Y, Z)
+        /// </returns>
+        public List<Point> GetPointsBetweenLowerUpperLimits(Point LowerLeftPoint, Point UpperRightPoint)
+        {
+            List<Point> points = new List<Point>();
+            double minX = LowerLeftPoint.X;
+            double minY = LowerLeftPoint.Y;
+            double maxX = UpperRightPoint.X;
+            double maxY = UpperRightPoint.Y;
+
+            List<Point> surfacePoints = this.GetSurfacePoints();
+
+            foreach (Point point in surfacePoints)
+            {
+                if (point.X >= minX && point.Y >= minY && point.X <= maxX && point.Y <= maxY)
+                {
+                    points.Add(point);
+                }
+            }
+
+            return points;
+        }
+
+        /// <summary>
+        /// Get surface points inside and along periphery of closed polygon
+        /// </summary>
+        /// <param name="lines"></param>
+        /// <returns></returns>
+        public List<Point> GetPointsInsidePolygon(List<Line> lines)
+        {
+            List<Point> pointList = new List<Point>();
+            List<Point> pointsInside = new List<Point>();
+            foreach (Line line in lines)
+            {
+                Point startPoint = line.StartPoint;
+                pointList.Add(startPoint);
+
+            }
+            double minX = pointList[0].X;
+            double minY = pointList[0].Y;
+            double maxX = pointList[0].X;
+            double maxY = pointList[0].Y;
+
+            for (int i = 0; i < pointList.Count; i++)
+            {
+                if (pointList[i].X < minX)
+                {
+                    minX = pointList[i].X;
+                }
+                if (pointList[i].Y < minY)
+                {
+                    minY = pointList[i].Y;
+                }
+                if (pointList[i].X > maxX)
+                {
+                    maxX = pointList[i].X;
+                }
+                if (pointList[i].Y > maxY)
+                {
+                    maxY = pointList[i].Y;
+                }
+            }
+            Point minPoint = Point.ByCoordinates(minX, minY);
+            Point maxPoint = Point.ByCoordinates(maxX, maxY);
+
+            List<Point> pointsBounding = GetPointsBetweenLowerUpperLimits(minPoint, maxPoint);
+
+            foreach (Point p in pointsBounding)
+            {
+                Point p1, p2;
+
+                bool inside = false;
+
+                if (pointList.Count < 3)
+                {
+                    pointsInside.Add(null);
+                }
+                else
+                {
+                    Point oldPoint = Point.ByCoordinates(pointList[pointList.Count - 1].X, pointList[pointList.Count - 1].Y);
+
+                    for (int j = 0; j < pointList.Count; j++)
+                    {
+                        Point newPoint = Point.ByCoordinates(pointList[j].X, pointList[j].Y);
+
+                        if (newPoint.X > oldPoint.X)
+                        {
+                            p1 = oldPoint;
+                            p2 = newPoint;
+                        }
+                        else
+                        {
+                            p1 = newPoint;
+                            p2 = oldPoint;
+                        }
+
+                        if ((newPoint.X < p.X) == (p.X <= oldPoint.X) && (p.Y - (long)p1.Y) * (p2.X - p1.X) < (p2.Y - (long)p1.Y) * (p.X - p1.X))
+                        {
+                            inside = !inside;
+                        }
+
+                        oldPoint = newPoint;
+
+                    }
+                    if (inside == true)
+                    {
+                        pointsInside.Add(p);
+                    }
+                }
+
+            }
+
+
+            return pointsInside;
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return string.Format("Surface(Name = {0})", this._surface.Name);
+        }
+
+        #endregion
+    }
+}

--- a/Src/CivilConnection/2020/Autodesk2020/CivilSurface.cs
+++ b/Src/CivilConnection/2020/Autodesk2020/CivilSurface.cs
@@ -51,10 +51,12 @@ namespace CivilConnection
 
         #region PUBLIC METHODS
         /// <summary>
-        /// 
+        /// Get elevation of surface at points
         /// </summary>
         /// <param name="points"></param>
-        /// <returns></returns>
+        /// <returns>
+        /// The List of Elevations
+        /// </returns>
         public List<object> GetElevationAtPoint(List<Point> points)
         {
             List<object> elevations = new List<object>();
@@ -62,7 +64,7 @@ namespace CivilConnection
             {
                 try
                 {
-                    double elevation = Math.Round(this._surface.FindElevationAtXY(point.X, point.Y), 3);
+                    double elevation = Math.Round(this._surface.FindElevationAtXY(point.X, point.Y), 5);
                     elevations.Add(elevation);
                 }
 
@@ -79,7 +81,9 @@ namespace CivilConnection
         /// Gets all surface points along line
         /// </summary>
         /// <param name="lines"></param>
-        /// <returns></returns>
+        /// <returns>
+        /// The List of Points
+        /// </returns>
         public List<List<object>> GetElevationsAlongLine(List<Line> lines)
         {
             List<List<object>> pointsOnLine = new List<List<object>>();
@@ -106,7 +110,7 @@ namespace CivilConnection
         /// Get all surface points
         /// </summary>
         /// <returns>
-        /// Point(X,Y,Z)
+        /// The List of Points
         /// </returns>
         public List<Point> GetSurfacePoints()
         {
@@ -125,18 +129,18 @@ namespace CivilConnection
         /// <summary>
         /// Gets all surface points between lower and upper limit point
         /// </summary>
-        /// <param name="LowerLeftPoint"></param>
-        /// <param name="UpperRightPoint"></param>
+        /// <param name="lowerLeftPoint"></param>
+        /// <param name="upperRightPoint"></param>
         /// <returns>
-        /// Point(X, Y, Z)
+        /// The List of Points
         /// </returns>
-        public List<Point> GetPointsBetweenLowerUpperLimits(Point LowerLeftPoint, Point UpperRightPoint)
+        public List<Point> GetPointsBetweenLowerUpperLimits(Point lowerLeftPoint, Point upperRightPoint)
         {
             List<Point> points = new List<Point>();
-            double minX = LowerLeftPoint.X;
-            double minY = LowerLeftPoint.Y;
-            double maxX = UpperRightPoint.X;
-            double maxY = UpperRightPoint.Y;
+            double minX = lowerLeftPoint.X;
+            double minY = lowerLeftPoint.Y;
+            double maxX = upperRightPoint.X;
+            double maxY = upperRightPoint.Y;
 
             List<Point> surfacePoints = this.GetSurfacePoints();
 
@@ -152,10 +156,12 @@ namespace CivilConnection
         }
 
         /// <summary>
-        /// Get surface points inside and along periphery of closed polygon
+        /// Get surface points inside closed polygon
         /// </summary>
         /// <param name="lines"></param>
-        /// <returns></returns>
+        /// <returns>
+        /// The List of Points
+        /// </returns>
         public List<Point> GetPointsInsidePolygon(List<Line> lines)
         {
             List<Point> pointList = new List<Point>();
@@ -195,58 +201,64 @@ namespace CivilConnection
 
             List<Point> pointsBounding = GetPointsBetweenLowerUpperLimits(minPoint, maxPoint);
 
-            foreach (Point p in pointsBounding)
+            if (pointsBounding.Count != 0)
             {
-                Point p1, p2;
-
-                bool inside = false;
-
-                if (pointList.Count < 3)
+                foreach (Point p in pointsBounding)
                 {
-                    pointsInside.Add(null);
-                }
-                else
-                {
-                    Point oldPoint = Point.ByCoordinates(pointList[pointList.Count - 1].X, pointList[pointList.Count - 1].Y);
+                    Point p1, p2;
 
-                    for (int j = 0; j < pointList.Count; j++)
+                    bool inside = false;
+
+                    if (pointList.Count < 3)
                     {
-                        Point newPoint = Point.ByCoordinates(pointList[j].X, pointList[j].Y);
-
-                        if (newPoint.X > oldPoint.X)
-                        {
-                            p1 = oldPoint;
-                            p2 = newPoint;
-                        }
-                        else
-                        {
-                            p1 = newPoint;
-                            p2 = oldPoint;
-                        }
-
-                        if ((newPoint.X < p.X) == (p.X <= oldPoint.X) && (p.Y - (long)p1.Y) * (p2.X - p1.X) < (p2.Y - (long)p1.Y) * (p.X - p1.X))
-                        {
-                            inside = !inside;
-                        }
-
-                        oldPoint = newPoint;
-
+                        pointsInside.Add(null);
                     }
-                    if (inside == true)
+                    else
                     {
-                        pointsInside.Add(p);
-                    }
-                }
+                        Point oldPoint = Point.ByCoordinates(pointList[pointList.Count - 1].X, pointList[pointList.Count - 1].Y);
 
+                        for (int j = 0; j < pointList.Count; j++)
+                        {
+                            Point newPoint = Point.ByCoordinates(pointList[j].X, pointList[j].Y);
+
+                            if (newPoint.X > oldPoint.X)
+                            {
+                                p1 = oldPoint;
+                                p2 = newPoint;
+                            }
+                            else
+                            {
+                                p1 = newPoint;
+                                p2 = oldPoint;
+                            }
+
+                            if ((newPoint.X < p.X) == (p.X <= oldPoint.X) && (p.Y - (long)p1.Y) * (p2.X - p1.X) < (p2.Y - (long)p1.Y) * (p.X - p1.X))
+                            {
+                                inside = !inside;
+                            }
+
+                            oldPoint = newPoint;
+
+                        }
+                        if (inside == true)
+                        {
+                            pointsInside.Add(p);
+                        }
+                    }
+
+                }
             }
-
 
             return pointsInside;
         }
+        
+                
         /// <summary>
-        /// 
+        /// Public textual representation in the Dynamo node preview.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
         public override string ToString()
         {
             return string.Format("Surface(Name = {0})", this._surface.Name);


### PR DESCRIPTION
Hi Paolo,

I have forked the CivilConnection from GitHub and added some of the additional Dynamo nodes related to Civil 3D surfaces, as they are not included in the current version of CivilConnection.

I have tested the CivilConnection package with new nodes using Autodesk Civil 3D 2019 and Revit 2019, but the same nodes can work for 2020 version also.

I created nodes as they are useful for us in our current projects.
e.g. 
1. GetElevationAtPoint for getting selected surface elevation at a point to update the foundation depth of structure or pile. 
2. GetElevationsAlongLine is useful to generate a surface profile along a line in Revit
3. GetPointsInsidePolygon together with GetElevationsAlongLine is used to create a topography of a selected area.
The details of all new Dynamo nodes are in the attached file.
[CivilConnectionContribution.docx](https://github.com/Autodesk/civilconnection/files/3590063/CivilConnectionContribution.docx)
